### PR TITLE
LE: ingress domain is now in `.status.domain`

### DIFF
--- a/Lets_Encrypt_Certificates_for_OCP4.adoc
+++ b/Lets_Encrypt_Certificates_for_OCP4.adoc
@@ -69,7 +69,7 @@ export LE_API=$(oc whoami --show-server | cut -f 2 -d ':' | cut -f 3 -d '/' | se
 +
 [source,sh]
 ----
-export LE_WILDCARD=$(oc get ingresscontroller default -n openshift-ingress-operator -o jsonpath='{.status.ingressDomain}')
+export LE_WILDCARD=$(oc get ingresscontroller default -n openshift-ingress-operator -o jsonpath='{.status.domain}')
 ----
 
 . Run the acme.sh script


### PR DESCRIPTION
Ingress domain is stored in `.path.domain` now